### PR TITLE
Fix date formatting for years < 1000

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -25,7 +25,7 @@ mergeLists <- function (base_list, overlay_list, recursive = TRUE) {
 asISO8601Time <- function(x) {
   if (!inherits(x, "POSIXct"))
     x <- as.POSIXct(x, tz = "GMT")
-  format(x, format="%Y-%m-%dT%H:%M:%SZ", tz='GMT')
+  format(x, format="%04Y-%m-%dT%H:%M:%SZ", tz='GMT')
 }
 
 resolveStrokePattern <- function(strokePattern) {


### PR DESCRIPTION
Fixes date axes for e.g:
```
dygraph(ts(rnorm(1000)))
```
