### PR TITLE
Check JavaScript correctness of the generated html files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .RData
 .DS_Store
 packrat/lib*/
-
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 HTML_FILES := $(patsubst %.Rmd, %.html ,$(wildcard *.Rmd)) \
               $(patsubst %.md, %.html ,$(wildcard *.md))
 
-all: clean html
+NODE_MODULES := $(CURDIR)/node_modules
+PHANTOMJS := $(NODE_MODULES)/.bin/phantomjs
+
+all: clean html check
 
 
 html: $(HTML_FILES)
@@ -13,7 +16,12 @@ html: $(HTML_FILES)
 %.html: %.md
 	R --slave -e "set.seed(100);rmarkdown::render('$<')"
 
-.PHONY: clean
+$(NODE_MODULES):
+	npm install
+
+.PHONY: clean html check
 clean:
 	$(RM) $(HTML_FILES)
 
+check: $(NODE_MODULES) html
+	$(PHANTOMJS) check.js

--- a/check.js
+++ b/check.js
@@ -1,0 +1,43 @@
+var fs = require('fs');
+var path = fs.workingDirectory;
+var listReducer = function (p, c) {
+  var re = /\.html$/;
+  if (re.test(c)) {
+    p.push(path + fs.separator + c);
+  }
+  return p;
+};
+var list = fs.list(path).reduce(listReducer, []);
+var page = require('webpage').create();
+var loadInProgress = false;
+var pageIndex = 0;
+
+var interval = setInterval(function () {
+  if (!loadInProgress && pageIndex < list.length) {
+    page.open(list[pageIndex]);
+  }
+  if (pageIndex == list.length) {
+    phantom.exit();
+  }
+}, 250);
+
+page.onLoadStarted = function () {
+  loadInProgress = true;
+};
+
+page.onLoadFinished = function () {
+  loadInProgress = false;
+  pageIndex++;
+}
+page.onError = function (msg, trace) {
+  var msgStack = [
+    'URL: ' + page.url,
+    'ERROR: ' + msg
+  ];
+  msgStack.push('TRACE:');
+  trace.forEach(function (t) {
+    msgStack.push('\t' + t.file + ': ' + t.line + (t.function ? ' (in function "' + t.function +'")' : ''));
+  });
+  console.error(msgStack.join('\n'));
+  phantom.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dygraphs",
+  "devDependencies": {
+    "phantomjs": "^1.9.18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rstudio/dygraphs.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rstudio/dygraphs/issues"
+  },
+  "homepage": "https://github.com/rstudio/dygraphs#readme",
+  "description": "R interface to dygraphs"
+}


### PR DESCRIPTION
This PR introduces the new `make check` target, which checks for JavaScript correctness of the generated html files with [PhatnomJS](http://phantomjs.org/).

Requires [nodejs](https://nodejs.org/).