### PR TITLE
Support for numeric x-axis

### DIFF
--- a/R/annotation.R
+++ b/R/annotation.R
@@ -4,8 +4,9 @@
 #' Define a text annotation for a data-point on a dygraph chart.
 #' 
 #' @param dygraph Dygraph to add an annotation to
-#' @param x Date value indicating where to place the annotation. This should be 
-#'   of class \code{POSIXct} or convertible to \code{POSIXct}.
+#' @param x Either numeric or date value indicating where to place the
+#'   annotation. For date value, this should be of class \code{POSIXct} or
+#'   convertible to \code{POSIXct}.
 #' @param text Text to overlay on the chart at the location of x
 #' @param tooltip Additional tooltip text to display on mouse hover
 #' @param width Width (in pixels) of the annotation flag.
@@ -65,8 +66,9 @@ dyAnnotation <- function(dygraph,
                          dblClickHandler = NULL,
                          series = NULL) {
   
-  # convert x to date format then to a suitable time value
-  x <- asISO8601Time(x)
+  # convert x to date format then to a suitable time value if it is date format
+  if (dygraph$x$format == "date")
+    x <- asISO8601Time(x)
   
   # validate series if specified
   if (!is.null(series) && ! series %in% dygraph$x$attrs$labels) {

--- a/R/axis.R
+++ b/R/axis.R
@@ -77,7 +77,7 @@
 #' 
 #' dygraph(nhtemp, main = "New Haven Temperatures") %>%
 #'   dyAxis("y", label = "Temp (F)", valueRange = c(40, 60)) %>%
-#'   dyOptions(axisLineWidth = 1.5, fillGraph = TRUE, drawGrid = FALSE)  
+#'   dyOptions(axisLineWidth = 1.5, fillGraph = TRUE, drawGrid = FALSE)
 #'     
 #' @export
 dyAxis <- function(dygraph,

--- a/R/dygraph.R
+++ b/R/dygraph.R
@@ -3,9 +3,9 @@
 #' R interface to interactive time series plotting using the 
 #' \href{http://dygraphs.com}{dygraphs} JavaScript library.
 #' 
-#' @param data Either Time series data or numeric data (For time series, this
+#' @param data Either time series data or numeric data. (For time series, this
 #'   must be an \link[xts]{xts} object or an object which is convertible to
-#'   \code{xts}. For numeric data, this must be a named list or data frame).
+#'   \code{xts}. For numeric data, this must be a named list or data frame)
 #' @param periodicity Periodicity of time series data (automatically detected
 #'   via \link[xts:periodicity]{xts::periodicity} if not specified).
 #' @param main Main plot title (optional)

--- a/R/dygraph.R
+++ b/R/dygraph.R
@@ -3,10 +3,11 @@
 #' R interface to interactive time series plotting using the 
 #' \href{http://dygraphs.com}{dygraphs} JavaScript library.
 #' 
-#' @param data Time series data (must be an \link[xts]{xts} object or an object 
-#'   which is convertible to \code{xts}).
-#' @param periodicity Periodicity of data (automatically detected via
-#'   \link[xts:periodicity]{xts::periodicity} if not specified).
+#' @param data Either Time series data or numeric data (For time series, this
+#'   must be an \link[xts]{xts} object or an object which is convertible to
+#'   \code{xts}. For numeric data, this must be a named list or data frame).
+#' @param periodicity Periodicity of time series data (automatically detected
+#'   via \link[xts:periodicity]{xts::periodicity} if not specified).
 #' @param main Main plot title (optional)
 #' @param xlab X axis label
 #' @param ylab Y axis label
@@ -26,35 +27,33 @@
 #' lungDeaths <- cbind(mdeaths, fdeaths)
 #' dygraph(lungDeaths)
 #' 
+#' indoConc <- Indometh[Indometh$Subject == 1, c("time", "conc")]
+#' dygraph(indoConc)
+#' 
 #' @export
 dygraph <- function(data, main = NULL, xlab = NULL, ylab = NULL,
                     periodicity = NULL, group = NULL, 
                     width = NULL, height = NULL) {
   
   # Test whether x-axis are dates or numeric
-  if (xts::xtsible(data))
-  {
-    format <- "date"
+  if (xts::xtsible(data)) {
+    
     if (!xts::is.xts(data))
       data <- xts::as.xts(data)
-  }
-  else if (is.list(data) && is.numeric(data[[1]]))
-  {
+    format <- "date"
+    
+  } else if (is.list(data) && is.numeric(data[[1]])) {
+    
     if (is.null(names(data)))
       stop("For numeric values, 'data' must be a named list or data frame")
     format <- "numeric"
-  }
-  else
-  {
+    
+  } else {
     stop("Unsupported type passed to argument 'data'.")
   }
   
-#   # convert data to xts
-#   if (!xts::is.xts(data))
-#     data <- xts::as.xts(data)
-  
-  if (format == "date")
-  {
+  if (format == "date") {
+    
     # auto-detect periodicity if not otherwise specified
     if (is.null(periodicity)) {
       if (nrow(data) < 2) {
@@ -75,13 +74,10 @@ dygraph <- function(data, main = NULL, xlab = NULL, ylab = NULL,
     timeColumn <- list()
     timeColumn[[periodicity$label]] <- asISO8601Time(time)
     data <- append(timeColumn, data)
-  }
-  else
-  {
+  } else {
     # Convert data to list if it was data frame
     data <- as.list(data)
   }
-  
   
   # create native dygraph attrs object
   attrs <- list()

--- a/R/event.R
+++ b/R/event.R
@@ -3,8 +3,10 @@
 #' Add a vertical event line to a dygraph
 #' 
 #' @param dygraph Dygraph to add event line to
-#' @param date Date/time for the event (must be a \code{POSIXct} object or 
-#'   another object convertible to \code{POSIXct} via \code{as.POSIXct})
+#' @param x Either numeric or date/time for the event, depending on the format
+#'   of the x-axis of the dygraph. (For date/time must be a \code{POSIXct}
+#'   object or another object convertible to \code{POSIXct} via
+#'   \code{as.POSIXct})
 #' @param label Label for event. Defaults to blank.
 #' @param labelLoc Location for label (top or bottom)
 #' @param color Color of event line. This can be of the form "#AABBCC" or 
@@ -28,7 +30,7 @@
 #'  
 #' @export
 dyEvent <- function(dygraph, 
-                    date,
+                    x,
                     label = NULL, 
                     labelLoc = c("top", "bottom"),
                     color = "black", 
@@ -36,7 +38,7 @@ dyEvent <- function(dygraph,
   
   # create event
   event <- list()
-  event$pos <- asISO8601Time(date)
+  event$pos <- ifelse(dygraph$x$format == "date", asISO8601Time(x), x)
   event$label <- label
   event$labelLoc <- match.arg(labelLoc)
   event$color <- color

--- a/R/range-selector.R
+++ b/R/range-selector.R
@@ -56,7 +56,11 @@ dyRangeSelector <- function(dygraph,
   if (!is.null(dateWindow)) {
     if (length(dateWindow) != 2)
       stop("dateWindow must be vector of length 2 that is convertible to POSIXct")
-    selector$dateWindow <- sapply(USE.NAMES = FALSE, dateWindow, asISO8601Time)
+    # TODO: Rename dateWindow argument?
+    if (dygraph$x$format == "date")
+      selector$dateWindow <- sapply(USE.NAMES = FALSE, dateWindow, asISO8601Time)
+    else
+      selector$dateWindow <- dateWindow
   }
   selector$rangeSelectorHeight <- height
   selector$rangeSelectorPlotFillColor <- fillColor

--- a/R/shading.R
+++ b/R/shading.R
@@ -3,11 +3,11 @@
 #' Specify that a region of a dygraph be drawn with a background shading
 #' 
 #' @param dygraph Dygraph to add shading to
-#' @param from Date/time to shade from (must be a \code{as.POSIXct} object or 
-#'   another object convertible to \code{as.POSIXct}). convertible via 
+#' @param from Date/time or numeric to shade from (for date/time this must be a
+#'   \code{as.POSIXct} object or another object convertible via
 #'   \code{as.POSIXct}).
-#' @param to Date/time to shade to (must be a \code{as.POSIXct} object or 
-#'   another object convertible to \code{as.POSIXct}). convertible via 
+#' @param to Date/time or numeric to shade to (for date/time this must be a
+#'   \code{as.POSIXct} object or another object convertible via
 #'   \code{as.POSIXct}).
 #' @param color Color of shading. This can be of the form "#AABBCC" or 
 #'   "rgb(255,100,200)" or "yellow". Defaults to a very light gray.
@@ -35,8 +35,10 @@ dyShading <- function(dygraph, from, to, color = "#EFEFEF", axis = "x") {
   
   # create shading
   shading <- list()
-  shading$from <- ifelse(axis == "x", asISO8601Time(from), from)
-  shading$to <- ifelse(axis == "x", asISO8601Time(to), to)
+  shading$from <- ifelse(axis == "x" && dygraph$x$format == "date",
+                         asISO8601Time(from), from)
+  shading$to <- ifelse(axis == "x" && dygraph$x$format == "date",
+                       asISO8601Time(to), to)
   shading$color <- color
   shading$axis <- axis
  

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -27,7 +27,7 @@ HTMLWidgets.widget({
 
   type: "output",
 
-  initialize: function(el, width, height) { 
+  initialize: function(el, width, height) {
     return {};
   },
 
@@ -37,20 +37,20 @@ HTMLWidgets.widget({
   },
 
   renderValue: function(el, x, instance) {
-    
+
     // reference to this for closures
     var thiz = this;
-    
+
     // get dygraph attrs and populate file field
     var attrs = x.attrs;
     attrs.file = x.data;
-    
+
     // convert non-arrays to arrays
     for (var index = 0; index < attrs.file.length; index++) {
       if (!$.isArray(attrs.file[index]))
         attrs.file[index] = [].concat(attrs.file[index]);
     }
-        
+
     // resolve "auto" legend behavior
     if (x.attrs.legend == "auto") {
       if (x.data.length <= 2)
@@ -58,57 +58,60 @@ HTMLWidgets.widget({
       else
         x.attrs.legend = "always";
     }
-    
-    // set appropriated function in case of fixed tz
-    if ((attrs.axes.x.axisLabelFormatter === undefined) && x.fixedtz)
-      attrs.axes.x.axisLabelFormatter = this.xAxisLabelFormatterFixedTZ(x.tzone);
-      
-    if ((attrs.axes.x.valueFormatter === undefined) && x.fixedtz)
-      attrs.axes.x.valueFormatter = this.xValueFormatterFixedTZ(x.scale, x.tzone);
 
-    if ((attrs.axes.x.ticker === undefined) && x.fixedtz)
-      attrs.axes.x.ticker = this.customDateTickerFixedTZ(x.tzone);
-  
-    // provide an automatic x value formatter if none is already specified
-    if ((attrs.axes.x.valueFormatter === undefined) && (x.fixedtz != true))
-      attrs.axes.x.valueFormatter = this.xValueFormatter(x.scale);
-    
-    // convert time to js time
-    attrs.file[0] = attrs.file[0].map(function(value) {
-      return thiz.normalizeDateValue(x.scale, value, x.fixedtz);
-    });
-    if (attrs.dateWindow != null) {
-      attrs.dateWindow = attrs.dateWindow.map(function(value) {
-        var date = thiz.normalizeDateValue(x.scale, value, x.fixedtz);
-        return date.getTime();
+    if (x.format == "date")
+    {
+      // set appropriated function in case of fixed tz
+      if ((attrs.axes.x.axisLabelFormatter === undefined) && x.fixedtz)
+        attrs.axes.x.axisLabelFormatter = this.xAxisLabelFormatterFixedTZ(x.tzone);
+
+      if ((attrs.axes.x.valueFormatter === undefined) && x.fixedtz)
+        attrs.axes.x.valueFormatter = this.xValueFormatterFixedTZ(x.scale, x.tzone);
+
+      if ((attrs.axes.x.ticker === undefined) && x.fixedtz)
+        attrs.axes.x.ticker = this.customDateTickerFixedTZ(x.tzone);
+
+      // provide an automatic x value formatter if none is already specified
+      if ((attrs.axes.x.valueFormatter === undefined) && (x.fixedtz != true))
+        attrs.axes.x.valueFormatter = this.xValueFormatter(x.scale);
+
+      // convert time to js time
+      attrs.file[0] = attrs.file[0].map(function(value) {
+        return thiz.normalizeDateValue(x.scale, value, x.fixedtz);
       });
+      if (attrs.dateWindow != null) {
+        attrs.dateWindow = attrs.dateWindow.map(function(value) {
+          var date = thiz.normalizeDateValue(x.scale, value, x.fixedtz);
+          return date.getTime();
+        });
+      }
     }
-    
+
     // transpose array
     attrs.file = HTMLWidgets.transposeArray2D(attrs.file);
-    
+
     // add drawCallback for group
     if (x.group != null)
-      this.addGroupDrawCallback(x);  
-      
+      this.addGroupDrawCallback(x);
+
     // add shading and event callback if necessary
     this.addShadingCallback(x);
     this.addEventCallback(x);
     this.addZoomCallback(x, instance);
-      
-    
+
+
     // if there is no existing instance perform one-time initialization
     if (!instance.dygraph) {
-      
+
       // subscribe to custom shown event (fired by ioslides to trigger
       // shiny reactivity but we can use it as well). this is necessary
       // because if a dygraph starts out as display:none it has height
       // and width == 0 and this doesn't change when it becomes visible
       $(el).closest('slide').on('shown', function() {
         if (instance.dygraph)
-          instance.dygraph.resize();  
+          instance.dygraph.resize();
       });
-      
+
       // add default font for viewer mode
       if (this.queryVar("viewer_pane") === "1")
         document.body.style.fontFamily = "Arial, sans-serif";
@@ -117,64 +120,66 @@ HTMLWidgets.widget({
       if (x.css != null) {
         var style = document.createElement('style');
         style.type = 'text/css';
-        if (style.styleSheet) 
+        if (style.styleSheet)
           style.styleSheet.cssText = x.css;
-        else 
+        else
           style.appendChild(document.createTextNode(x.css));
         document.getElementsByTagName("head")[0].appendChild(style);
       }
-      
+
     } else {
-      
+
         // retain the userDateWindow if requested
         if (instance.dygraph.userDateWindow != null
             && attrs.retainDateWindow == true) {
           attrs.dateWindow = instance.dygraph.xAxisRange();
         }
-            
+
         // remove it from groups if it's there
         if (x.group != null && this.groups[x.group] != null) {
           var index = this.groups[x.group].indexOf(instance.dygraph);
           if (index != -1)
             this.groups[x.group].splice(index, 1);
         }
-        
-        // destroy the existing dygraph 
+
+        // destroy the existing dygraph
         instance.dygraph.destroy();
         instance.dygraph = null;
     }
-    
+
     // add shiny input for date window
     if (HTMLWidgets.shinyMode)
       this.addDateWindowShinyInput(el.id, x);
-    
+
     // create the instance and add it to it's group (if any)
     instance.dygraph = new Dygraph(el, attrs.file, attrs);
     instance.dygraph.userDateWindow = attrs.dateWindow;
     if (x.group != null)
       this.groups[x.group].push(instance.dygraph);
-    
+
     // set annotations
     if (x.annotations != null) {
       instance.dygraph.ready(function() {
-        x.annotations.map(function(annotation) {
-          var date = thiz.normalizeDateValue(x.scale, annotation.x, x.fixedtz);
-          annotation.x = date.getTime();
-        });
+        if (x.format == "date") {
+          x.annotations.map(function(annotation) {
+            var date = thiz.normalizeDateValue(x.scale, annotation.x, x.fixedtz);
+            annotation.x = date.getTime();
+          });
+        }
         instance.dygraph.setAnnotations(x.annotations);
-      }); 
+      });
     }
-      
+
   },
-  
+
   // set of functions needed with fixed tz
   customDateTickerFixedTZ : function(tz){
-    return function(a, b, pixels, opts, dygraph, vals) {   
+    return function(a, b, pixels, opts, dygraph, vals) {
       var chosen = Dygraph.pickDateTickGranularity(a, b, pixels, opts);
       if (chosen >= 0) {
         var formatter = (opts("axisLabelFormatter"));
         var ticks = [];
-        var t; 
+        var t;
 
         if (chosen < Dygraph.MONTHLY) {
           // Generate one tick mark for every fixed interval of time.
@@ -184,16 +189,16 @@ HTMLWidgets.widget({
           // for this granularity.
           var g = spacing / 1000;
           var d = moment(a);
-          d.tz(tz); 
+          d.tz(tz);
           d.millisecond(0);
 
           var x;
-          if (g <= 60) {  // seconds 
-            x = d.second();         
-            d.second(x - x % g);     
+          if (g <= 60) {  // seconds
+            x = d.second();
+            d.second(x - x % g);
           } else {
             d.second(0);
-            g /= 60; 
+            g /= 60;
             if (g <= 60) {  // minutes
               x = d.minute();
               d.minute(x - x % g);
@@ -268,7 +273,7 @@ HTMLWidgets.widget({
           for (var i = start_year; i <= end_year; i++) {
             if (i % year_mod !== 0) continue;
             for (var j = 0; j < months.length; j++) {
-              var dt = moment.tz(new Date(i, months[j], 1), tz); 
+              var dt = moment.tz(new Date(i, months[j], 1), tz);
               dt.year(i);
               t = dt.valueOf();
               if (t < a || t > b) continue;
@@ -287,7 +292,7 @@ HTMLWidgets.widget({
   },
 
   xAxisLabelFormatterFixedTZ : function(tz){
-  
+
     return function dateAxisFormatter(date, granularity){
       var mmnt = moment(date).tz(tz);
       if (granularity >= Dygraph.DECADAL){
@@ -306,14 +311,14 @@ HTMLWidgets.widget({
                return mmnt.format('HH:mm');
              }
             }
-         } 
-                        
-       }         
+         }
+
+       }
    }
   },
-         
+
   xValueFormatterFixedTZ: function(scale, tz) {
-                   
+
     return function(millis) {
       var mmnt = moment(millis).tz(tz);
         if (scale == "yearly")
@@ -326,44 +331,44 @@ HTMLWidgets.widget({
           return mmnt.format('dddd, MMMM, DD, YYYY HH:mm:ss')+ ' (' + mmnt.zoneAbbr() + ')';
     }
   },
-  
+
   xValueFormatter: function(scale) {
-    
-    var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", 
+
+    var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                       "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-                      
+
     return function(millis) {
       var date = new Date(millis);
         if (scale == "yearly")
           return date.getFullYear();
         else if (scale == "monthly" || scale == "quarterly")
-          return monthNames[date.getMonth()] + ', ' + date.getFullYear(); 
+          return monthNames[date.getMonth()] + ', ' + date.getFullYear();
         else if (scale == "daily" || scale == "weekly")
-          return monthNames[date.getMonth()] + ', ' + 
-                           date.getDate() + ', ' + 
+          return monthNames[date.getMonth()] + ', ' +
+                           date.getDate() + ', ' +
                            date.getFullYear();
         else
           return date.toLocaleString();
     }
   },
-  
+
   addZoomCallback: function(x, instance) {
-    
+
     // alias this
     var thiz = this;
-    
+
     // get attrs
     var attrs = x.attrs;
-    
+
     // check for an existing zoomCallback
     var prevZoomCallback = attrs["zoomCallback"];
-    
+
     attrs.zoomCallback = function(minDate, maxDate, yRanges) {
-      
+
       // call existing
       if (prevZoomCallback)
         prevZoomCallback(minDate, maxDate, yRanges);
-        
+
       // record user date window (or lack thereof)
       var me = instance.dygraph;
       if (me.xAxisExtremes()[0] != minDate ||
@@ -372,7 +377,7 @@ HTMLWidgets.widget({
       } else {
          me.userDateWindow = null;
       }
-      
+
       // record in group if necessary
       if (x.group != null && thiz.groups[x.group] != null) {
         var group = thiz.groups[x.group];
@@ -381,27 +386,27 @@ HTMLWidgets.widget({
       }
     };
   },
-  
-  
+
+
   groups: {},
-  
+
   addGroupDrawCallback: function(x) {
-    
+
     // get attrs
     var attrs = x.attrs;
-    
+
     // check for an existing drawCallback
     var prevDrawCallback = attrs["drawCallback"];
-    
+
     this.groups[x.group] = this.groups[x.group] || [];
     var group = this.groups[x.group];
     var blockRedraw = false;
     attrs.drawCallback = function(me, initial) {
-      
+
       // call existing
       if (prevDrawCallback)
         prevDrawCallback(me, initial);
-      
+
       // sync peers in group
       if (blockRedraw || initial) return;
       blockRedraw = true;
@@ -420,29 +425,29 @@ HTMLWidgets.widget({
       blockRedraw = false;
     };
   },
-  
+
   addShadingCallback: function(x) {
-    
+
     // bail if no shadings
     if (x.shadings.length == 0)
       return;
-    
+
     // alias this
     var thiz = this;
-    
+
     // get attrs
     var attrs = x.attrs;
-    
+
     // check for an existing underlayCallback
     var prevUnderlayCallback = attrs["underlayCallback"];
-    
+
     // install callback
     attrs.underlayCallback = function(canvas, area, g) {
-      
+
       // call existing
       if (prevUnderlayCallback)
         prevUnderlayCallback(canvas, area, g);
-        
+
       for (var i = 0; i < x.shadings.length; i++) {
         var shading = x.shadings[i];
         canvas.save();
@@ -452,7 +457,7 @@ HTMLWidgets.widget({
           var x2 = thiz.normalizeDateValue(x.scale, shading.to, x.fixedtz).getTime();
           var left = g.toDomXCoord(x1);
           var right = g.toDomXCoord(x2);
-          
+
           canvas.fillRect(left, area.y, right - left, area.h);
         } else if (shading.axis == "y") {
           var bottom = g.toDomYCoord(shading.from);
@@ -464,60 +469,65 @@ HTMLWidgets.widget({
       }
     };
   },
-  
+
   addEventCallback: function(x) {
-    
+
     // bail if no evets
     if (x.events.length == 0)
       return;
-    
+
     // alias this
     var thiz = this;
-    
+
     // get attrs
     var attrs = x.attrs;
-    
+
     // check for an existing underlayCallback
     var prevUnderlayCallback = attrs["underlayCallback"];
-    
+
     // install callback
     attrs.underlayCallback = function(canvas, area, g) {
-      
+
       // call existing
       if (prevUnderlayCallback)
         prevUnderlayCallback(canvas, area, g);
-        
+
       for (var i = 0; i < x.events.length; i++) {
-        
+
         // get event and x-coordinate
         var event = x.events[i];
-        
+
         // draw line
         canvas.save();
         canvas.strokeStyle = event.color;
         if (event.axis == "x") {
-          var xPos = thiz.normalizeDateValue(x.scale, event.pos, x.fixedtz).getTime();
-          xPos = g.toDomXCoord(xPos);
-          
+          var xPos;
+          if (jQuery.isNumeric(event.pos)) {
+            xPos = g.toDomXCoord(event.pos);
+          } else {
+            xPos = thiz.normalizeDateValue(x.scale, event.pos, x.fixedtz).getTime();
+            xPos = g.toDomXCoord(xPos);
+          }
+
           // draw line
-          thiz.dashedLine(canvas, 
-                          xPos, 
-                          area.y, 
-                          xPos, 
+          thiz.dashedLine(canvas,
+                          xPos,
+                          area.y,
+                          xPos,
                           area.y + area.h,
                           event.strokePattern);
         } else if (event.axis == "y") {
           yPos = g.toDomYCoord(event.pos);
-          
-          thiz.dashedLine(canvas, 
-                          area.x, 
-                          yPos, 
-                          area.x + area.w, 
+
+          thiz.dashedLine(canvas,
+                          area.x,
+                          yPos,
+                          area.x + area.w,
                           yPos,
                           event.strokePattern);
         }
         canvas.restore();
-        
+
         // draw label
         if (event.label != null) {
           canvas.save();
@@ -547,26 +557,26 @@ HTMLWidgets.widget({
       }
     };
   },
-  
+
   addDateWindowShinyInput: function(id, x) {
-      
+
     // check for an existing drawCallback
     var prevDrawCallback = x.attrs["drawCallback"];
-    
+
     // install the callback
     x.attrs.drawCallback = function(me, initial) {
-      
+
       // call existing
       if (prevDrawCallback)
         prevDrawCallback(me, initial);
-        
+
       // fire input change
       var range = me.xAxisRange();
       var dateWindow = [new Date(range[0]), new Date(range[1])];
-      Shiny.onInputChange(id + "_date_window", dateWindow); 
+      Shiny.onInputChange(id + "_date_window", dateWindow);
     };
   },
-  
+
   // Add dashed line support to canvas rendering context
   // See: http://stackoverflow.com/questions/4576724/dotted-stroke-in-canvas
   dashedLine: function(canvas, x, y, x2, y2, dashArray) {
@@ -592,7 +602,7 @@ HTMLWidgets.widget({
     }
     canvas.stroke();
   },
-  
+
   setFontSize: function(canvas, size) {
     var cFont = canvas.font;
     var parts = cFont.split(' ');
@@ -601,7 +611,7 @@ HTMLWidgets.widget({
     else if (parts.length === 3)
       canvas.font = parts[0] + ' ' + size + 'px ' + parts[2];
   },
-  
+
   // Returns the value of a GET variable
   queryVar: function(name) {
     return decodeURI(window.location.search.replace(
@@ -610,8 +620,8 @@ HTMLWidgets.widget({
                  "(?:\\=([^&]*))?)?.*$", "i"),
       "$1"));
   },
-  
-  // We deal exclusively in UTC dates within R, however dygraphs deals 
+
+  // We deal exclusively in UTC dates within R, however dygraphs deals
   // exclusively in the local time zone. Therefore, in order to plot date
   // labels that make sense to the user when we are dealing with days,
   // months or years we need to convert the UTC date value to a local time
@@ -619,13 +629,12 @@ HTMLWidgets.widget({
   // timezone offset to the UTC date.
   // Don't use in case of fixedtz
   normalizeDateValue: function(scale, value, fixedtz) {
-    var date = new Date(value); 
+    var date = new Date(value);
     if (scale != "minute" && scale != "hourly" && scale != "seconds" && !fixedtz) {
       var localAsUTC = date.getTime() + (date.getTimezoneOffset() * 60000);
       date = new Date(localAsUTC);
     }
     return date;
   }
-  
-});
 
+});

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -459,8 +459,6 @@ HTMLWidgets.widget({
             x1 = thiz.normalizeDateValue(x.scale, x1, x.fixedtz).getTime();
             x2 = thiz.normalizeDateValue(x.scale, x2, x.fixedtz).getTime();
           }
-          //var x1 = thiz.normalizeDateValue(x.scale, shading.from, x.fixedtz).getTime();
-          //var x2 = thiz.normalizeDateValue(x.scale, shading.to, x.fixedtz).getTime();
           var left = g.toDomXCoord(x1);
           var right = g.toDomXCoord(x2);
 

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -453,8 +453,14 @@ HTMLWidgets.widget({
         canvas.save();
         canvas.fillStyle = shading.color;
         if (shading.axis == "x") {
-          var x1 = thiz.normalizeDateValue(x.scale, shading.from, x.fixedtz).getTime();
-          var x2 = thiz.normalizeDateValue(x.scale, shading.to, x.fixedtz).getTime();
+          var x1 = shading.from;
+          var x2 = shading.to;
+          if (x.format == "date") {
+            x1 = thiz.normalizeDateValue(x.scale, x1, x.fixedtz).getTime();
+            x2 = thiz.normalizeDateValue(x.scale, x2, x.fixedtz).getTime();
+          }
+          //var x1 = thiz.normalizeDateValue(x.scale, shading.from, x.fixedtz).getTime();
+          //var x2 = thiz.normalizeDateValue(x.scale, shading.to, x.fixedtz).getTime();
           var left = g.toDomXCoord(x1);
           var right = g.toDomXCoord(x2);
 

--- a/man/dyAnnotation.Rd
+++ b/man/dyAnnotation.Rd
@@ -12,8 +12,9 @@ dyAnnotation(dygraph, x, text, tooltip = NULL, width = NULL,
 \arguments{
 \item{dygraph}{Dygraph to add an annotation to}
 
-\item{x}{Date value indicating where to place the annotation. This should be
-of class \code{POSIXct} or convertible to \code{POSIXct}.}
+\item{x}{Either numeric or date value indicating where to place the
+annotation. For date value, this should be of class \code{POSIXct} or
+convertible to \code{POSIXct}.}
 
 \item{text}{Text to overlay on the chart at the location of x}
 

--- a/man/dyEvent.Rd
+++ b/man/dyEvent.Rd
@@ -4,14 +4,16 @@
 \alias{dyEvent}
 \title{dygraph event line}
 \usage{
-dyEvent(dygraph, date, label = NULL, labelLoc = c("top", "bottom"),
+dyEvent(dygraph, x, label = NULL, labelLoc = c("top", "bottom"),
   color = "black", strokePattern = "dashed")
 }
 \arguments{
 \item{dygraph}{Dygraph to add event line to}
 
-\item{date}{Date/time for the event (must be a \code{POSIXct} object or
-another object convertible to \code{POSIXct} via \code{as.POSIXct})}
+\item{x}{Either numeric or date/time for the event, depending on the format
+of the x-axis of the dygraph. (For date/time must be a \code{POSIXct}
+object or another object convertible to \code{POSIXct} via
+\code{as.POSIXct})}
 
 \item{label}{Label for event. Defaults to blank.}
 

--- a/man/dyShading.Rd
+++ b/man/dyShading.Rd
@@ -9,12 +9,12 @@ dyShading(dygraph, from, to, color = "#EFEFEF", axis = "x")
 \arguments{
 \item{dygraph}{Dygraph to add shading to}
 
-\item{from}{Date/time to shade from (must be a \code{as.POSIXct} object or
-another object convertible to \code{as.POSIXct}). convertible via
+\item{from}{Date/time or numeric to shade from (for date/time this must be a
+\code{as.POSIXct} object or another object convertible via
 \code{as.POSIXct}).}
 
-\item{to}{Date/time to shade to (must be a \code{as.POSIXct} object or
-another object convertible to \code{as.POSIXct}). convertible via
+\item{to}{Date/time or numeric to shade to (for date/time this must be a
+\code{as.POSIXct} object or another object convertible via
 \code{as.POSIXct}).}
 
 \item{color}{Color of shading. This can be of the form "#AABBCC" or

--- a/man/dygraph.Rd
+++ b/man/dygraph.Rd
@@ -8,8 +8,9 @@ dygraph(data, main = NULL, xlab = NULL, ylab = NULL, periodicity = NULL,
   group = NULL, width = NULL, height = NULL)
 }
 \arguments{
-\item{data}{Time series data (must be an \link[xts]{xts} object or an object
-which is convertible to \code{xts}).}
+\item{data}{Either Time series data or numeric data (For time series, this
+must be an \link[xts]{xts} object or an object which is convertible to
+\code{xts}. For numeric data, this must be a named list or data frame).}
 
 \item{main}{Main plot title (optional)}
 
@@ -17,8 +18,8 @@ which is convertible to \code{xts}).}
 
 \item{ylab}{Y axis label}
 
-\item{periodicity}{Periodicity of data (automatically detected via
-\link[xts:periodicity]{xts::periodicity} if not specified).}
+\item{periodicity}{Periodicity of time series data (automatically detected
+via \link[xts:periodicity]{xts::periodicity} if not specified).}
 
 \item{group}{Group to associate this plot with. The x-axis zoom level of
 plots within a group is automatically synchronized.}
@@ -42,5 +43,8 @@ additional details and examples.
 library(dygraphs)
 lungDeaths <- cbind(mdeaths, fdeaths)
 dygraph(lungDeaths)
+
+indoConc <- Indometh[Indometh$Subject == 1, c("time", "conc")]
+dygraph(indoConc)
 }
 

--- a/man/dygraph.Rd
+++ b/man/dygraph.Rd
@@ -8,9 +8,9 @@ dygraph(data, main = NULL, xlab = NULL, ylab = NULL, periodicity = NULL,
   group = NULL, width = NULL, height = NULL)
 }
 \arguments{
-\item{data}{Either Time series data or numeric data (For time series, this
+\item{data}{Either time series data or numeric data. (For time series, this
 must be an \link[xts]{xts} object or an object which is convertible to
-\code{xts}. For numeric data, this must be a named list or data frame).}
+\code{xts}. For numeric data, this must be a named list or data frame)}
 
 \item{main}{Main plot title (optional)}
 

--- a/man/dygraph.Rd
+++ b/man/dygraph.Rd
@@ -4,21 +4,21 @@
 \alias{dygraph}
 \title{dygraph interactive plot for time series data}
 \usage{
-dygraph(data, periodicity = NULL, main = NULL, xlab = NULL, ylab = NULL,
+dygraph(data, main = NULL, xlab = NULL, ylab = NULL, periodicity = NULL,
   group = NULL, width = NULL, height = NULL)
 }
 \arguments{
 \item{data}{Time series data (must be an \link[xts]{xts} object or an object
 which is convertible to \code{xts}).}
 
-\item{periodicity}{Periodicity of data (automatically detected via
-\link[xts:periodicity]{xts::periodicity} if not specified).}
-
 \item{main}{Main plot title (optional)}
 
 \item{xlab}{X axis label}
 
 \item{ylab}{Y axis label}
+
+\item{periodicity}{Periodicity of data (automatically detected via
+\link[xts:periodicity]{xts::periodicity} if not specified).}
 
 \item{group}{Group to associate this plot with. The x-axis zoom level of
 plots within a group is automatically synchronized.}

--- a/tests/testthat/test-event.R
+++ b/tests/testthat/test-event.R
@@ -3,8 +3,8 @@ context("dyEvent")
 
 test_that("event creation", {
   d <- dygraph(presidents, main = "Presidential Approval") %>%
-         dyEvent(date = "1950-6-30", "Korea", labelLoc = "bottom") %>%
-         dyEvent(date = "1965-2-09", "Vietnam", labelLoc = "bottom")   
+         dyEvent(x = "1950-6-30", "Korea", labelLoc = "bottom") %>%
+         dyEvent(x = "1965-2-09", "Vietnam", labelLoc = "bottom")   
   expect_equal(length(d$x$events), 2)
   expect_identical(d$x$events[[1]]$label, "Korea")
   expect_identical(d$x$events[[2]]$label, "Vietnam")


### PR DESCRIPTION
This PR adds support for numeric x-axis in dygraphs. Numeric-only data can be passed as either a named list or data frame. All dy* functions should work with a numeric x-axis.

TODO:
- [ ] I didn't change anything concerning shinyMode because I didn't work with Shiny so far
- [ ] Some arguments and variables might need to be renamed, such as the `dateWindow` argument in `dyRangeSelector`.