### PR TITLE
Deprecated options

### DIFF
--- a/R/axis.R
+++ b/R/axis.R
@@ -153,7 +153,7 @@ dyAxis <- function(dygraph,
   attrs$axes[[axis$name]] <- axis$options  
   
   # return modified dygraph
-  dygraph$x$attrs <- attrs
+  dygraph$x$attrs <- mergeLists(dygraph$x$attrs, attrs)
   dygraph
 }
 

--- a/R/options.R
+++ b/R/options.R
@@ -206,8 +206,8 @@ dyOptions <- function(dygraph,
     options$colors <- as.list(colors)
   options$colorValue <- colorValue
   options$colorSaturation <- colorSaturation
-  options$drawXAxis <- drawXAxis
-  options$drawYAxis <- drawYAxis
+  options$axes$x$drawAxis <- drawXAxis
+  options$axes$y$drawAxis <- drawYAxis
   options$includeZero <- includeZero
   options$drawAxesAtZero <- drawAxesAtZero
   options$logscale <- logscale


### PR DESCRIPTION
This PR introduces the changes to get rid of deprecated options `drawXAxis` and `drawYAxis` in favour of `axes : { x : { drawAxis } }` and `axes : { y : { drawAxis } }` correspondingly.