### PR TITLE
resolveStemPlot should return specified plotter

### DIFF
--- a/R/series.R
+++ b/R/series.R
@@ -262,8 +262,8 @@ resolveStemPlot <- function(stemPlot, plotter) {
        }
     }"
   } else {
-    # no custom plotter
-    NULL
+    # specified plotter
+    plotter
   }
 }
 

--- a/tests/testthat/test-plotter.R
+++ b/tests/testthat/test-plotter.R
@@ -1,0 +1,6 @@
+context("dyOptions")
+
+test_that("custom plotter", {
+  d <- dygraph(ldeaths) %>% dyOptions(plotter = "function(){}")
+  expect_false(is.null(d$x$attrs$plotter))
+})


### PR DESCRIPTION
There is a bug in `resolveStemPlot` function:

If the `stemPlot` value is `FALSE`, the function returns `NULL` no matter the previously set `plotter` value. So, this bug prevents using any other plotters then the default one or `stemPlotter`.

This PR fixes this bug.