### PR TITLE
handle milliseconds

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -25,7 +25,7 @@ mergeLists <- function (base_list, overlay_list, recursive = TRUE) {
 asISO8601Time <- function(x) {
   if (!inherits(x, "POSIXct"))
     x <- as.POSIXct(x, tz = "GMT")
-  format(x, format="%04Y-%m-%dT%H:%M:%SZ", tz='GMT')
+  format(x, format = "%04Y-%m-%dT%H:%M:%OS3Z", tz = 'GMT')
 }
 
 resolveStrokePattern <- function(strokePattern) {

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -3,6 +3,8 @@ dygraphs 1.1.1.0 (unreleased)
 
 * Properly handle NULL dyEvent label (#112)
 
+* Handle milliseconds in time events (#85)
+
 
 dygraphs 0.9
 --------------------------------------------------------------------------------


### PR DESCRIPTION
There are multiple issues on this problem, most recently #85.

This pull request just changes the formatter in `asISO8601Time` in order to take 3 decimal places for seconds. 

It has no impact on series without milliseconds and the base valueformatter is not changed so milliseconds are not natively displayed. See the example below to display them.

```r
library(dygraphs)
library(xts)

# Create posixct vector with milliseconds
op <- options(digits.secs = 3)
len <- 60 
RDData <- xts(runif(len, 0, 1), 
              seq(as.POSIXct("2015-04-01 10:00:00"),as.POSIXct("2015-04-01 10:05:00"), length = len),
              tz="GMT")

# Reset digits.secs
options(op)

# Draw it
dygraph(RDData) %>%
  dyAxis("x",
    valueFormatter = 'function(ms){    var d = new Date(ms);
                          return Dygraph.zeropad(d.getHours()) + ":" + 
                          Dygraph.zeropad(d.getMinutes()) + ":" + 
                          Dygraph.zeropad(d.getSeconds()) + "." + 
                          Dygraph.zeropad(d.getMilliseconds());}',
    ticker="Dygraph.dateTicker")
```