### PR TITLE
Click callbacks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dygraphs
 Type: Package
 Title: Interface to 'Dygraphs' Interactive Time Series Charting Library
-Version: 1.1.1.2
+Version: 1.1.1.3
 Date: 2016-09-14
 Authors@R: c(
     person("Dan", "Vanderkam", role = c("aut", "cph"),

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,5 +1,9 @@
+dygraphs 1.1.1.3 (unreleased)
+--------------------------------------------------------------------------------
 
-dygraphs 1.1.1.2 (unreleased)
+* Added callbacks that react when the user clicks on the graph
+
+dygraphs 1.1.1.2
 --------------------------------------------------------------------------------
 
 * Fix for shiny input binding regression introduced in move to instance

--- a/inst/examples/shiny/server.R
+++ b/inst/examples/shiny/server.R
@@ -17,23 +17,19 @@ shinyServer(function(input, output) {
   })
   
   output$from <- renderText({
-    if (!is.null(input$dygraph_date_window))
-      strftime(input$dygraph_date_window[[1]], "%d %b %Y")      
+    strftime(req(input$dygraph_date_window[[1]]), "%d %b %Y")
   })
   
   output$to <- renderText({
-    if (!is.null(input$dygraph_date_window))
-      strftime(input$dygraph_date_window[[2]], "%d %b %Y")
+    strftime(req(input$dygraph_date_window[[2]]), "%d %b %Y")
   })
   
   output$clicked <- renderText({
-	if (!is.null(input$dygraph_click))
-		strftime(input$dygraph_click$x, "%d %b %Y")
+    strftime(req(input$dygraph_click$x), "%d %b %Y")
   })
 
   output$point <- renderText({
-	if (!is.null(input$dygraph_click))
-		paste0('X = ', strftime(input$dygraph_click$x_closest_point, "%d %b %Y"), '; Y = ', input$dygraph_click$y_closest_point)
+    paste0('X = ', strftime(req(input$dygraph_click$x_closest_point), "%d %b %Y"), '; Y = ', req(input$dygraph_click$y_closest_point))
   })
   
 })

--- a/inst/examples/shiny/server.R
+++ b/inst/examples/shiny/server.R
@@ -27,7 +27,6 @@ shinyServer(function(input, output) {
   })
   
   output$clicked <- renderText({
-	print(input$dygraph_click)
 	if (!is.null(input$dygraph_click))
 		strftime(input$dygraph_click$x, "%d %b %Y")
   })

--- a/inst/examples/shiny/server.R
+++ b/inst/examples/shiny/server.R
@@ -24,5 +24,17 @@ shinyServer(function(input, output) {
   output$to <- renderText({
     if (!is.null(input$dygraph_date_window))
       strftime(input$dygraph_date_window[[2]], "%d %b %Y")
-  })  
+  })
+  
+  output$clicked <- renderText({
+	print(input$dygraph_click)
+	if (!is.null(input$dygraph_click))
+		strftime(input$dygraph_click$x, "%d %b %Y")
+  })
+
+  output$point <- renderText({
+	if (!is.null(input$dygraph_click))
+		paste0('X = ', strftime(input$dygraph_click$x_closest_point, "%d %b %Y"), '; Y = ', input$dygraph_click$y_closest_point)
+  })
+  
 })

--- a/inst/examples/shiny/ui.R
+++ b/inst/examples/shiny/ui.R
@@ -15,6 +15,8 @@ shinyUI(fluidPage(
       hr(),
       div(strong("From: "), textOutput("from", inline = TRUE)),
       div(strong("To: "), textOutput("to", inline = TRUE)),
+      div(strong("Date clicked: "), textOutput("clicked", inline = TRUE)),
+      div(strong("Nearest point clicked: "), textOutput("point", inline = TRUE)),
       br(),
       helpText("Click and drag to zoom in (double click to zoom back out).")
     ),

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -203,6 +203,24 @@ HTMLWidgets.widget({
         if (x.group != null)
           groups[x.group].push(dygraph);
         
+		// add callback
+		var prevClickCallback = dygraph.getOption("clickCallback")
+        dygraph.updateOptions({
+          clickCallback: function(e, x, points) {
+            // call existing
+            if (prevClickCallback)
+              prevClickCallback(e, x, points);
+			// fire input change
+            Shiny.onInputChange(el.id + "_click", {
+				x: new Date(x),
+				x_closest_point: new Date(points[0].xval),
+				y_closest_point: points[0].yval,
+				'.nonce': Math.random() // Force reactivity if click hasn't changed
+			}); 
+            
+          }
+        });		
+		
         // add shiny input for date window
         if (HTMLWidgets.shinyMode)
           this.addDateWindowShinyInput(el.id);


### PR DESCRIPTION
This pull request provides a callback when the user clicks on a dygraph.

Assuming that the dygraph is called "dygraph", clicking on the graph will re-actively update "input$dygraph_click" with the x-coordinate of click (in date-time format), and the x/y coordinates of the closest point to the click. The specific values are "input$dygraph_click$x", "input$dygraph_click$x_closest_point", and "input$dygraph_click$y_closest_point".

In addition to providing this functionality, I have also updated the shiny example to provide a use-case.

This added functionality will allow shiny app developers to develop even more responsive apps. For instance, #102 calls for the ability to react to a users mouse over on a dygraph. Although this doesn't seem possible based on the callbacks listed under the libraries documentation (http://dygraphs.com/options.html#Callbacks), the ability to react to a click is a good start.
