### PR TITLE
fix bug causing incorrect dates in shiny callbacks 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dygraphs
 Type: Package
 Title: Interface to 'Dygraphs' Interactive Time Series Charting Library
-Version: 1.1.1.3
+Version: 1.1.1.4
 Date: 2016-09-14
 Authors@R: c(
     person("Dan", "Vanderkam", role = c("aut", "cph"),

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+dygraphs 1.1.1.4 (unreleased)
+--------------------------------------------------------------------------------
+
+* Fixed bug where callbacks return incorrect dates to due to timezones
+
+
 dygraphs 1.1.1.3 (unreleased)
 --------------------------------------------------------------------------------
 

--- a/inst/examples/shiny/server.R
+++ b/inst/examples/shiny/server.R
@@ -25,7 +25,7 @@ shinyServer(function(input, output) {
   })
   
   output$clicked <- renderText({
-    format(strptime(req(input$dygraph_click$x), '%m/%d/%Y, %I:%M:%S %p'), '%Y/%m/%d %H:%M:%S')
+    format(strptime(req(input$dygraph_click$date), '%m/%d/%Y, %I:%M:%S %p'), '%Y/%m/%d %H:%M:%S')
   })
 
   output$point <- renderText({

--- a/inst/examples/shiny/server.R
+++ b/inst/examples/shiny/server.R
@@ -17,19 +17,22 @@ shinyServer(function(input, output) {
   })
   
   output$from <- renderText({
-    strftime(req(input$dygraph_date_window[[1]]), "%d %b %Y")      
+    format(strptime(req(input$dygraph_date_window[[1]]), '%m/%d/%Y, %I:%M:%S %p'), '%Y/%m/%d %H:%M:%S') 
   })
   
   output$to <- renderText({
-    strftime(req(input$dygraph_date_window[[2]]), "%d %b %Y")
+    format(strptime(req(input$dygraph_date_window[[2]]), "%m/%d/%Y, %I:%M:%S %p"), '%Y/%m/%d %H:%M:%S')
   })
   
   output$clicked <- renderText({
-    strftime(req(input$dygraph_click$x), "%d %b %Y")
+    format(strptime(req(input$dygraph_click$x), '%m/%d/%Y, %I:%M:%S %p'), '%Y/%m/%d %H:%M:%S')
   })
 
   output$point <- renderText({
-    paste0('X = ', strftime(req(input$dygraph_click$x_closest_point), "%d %b %Y"), 
-         '; Y = ', req(input$dygraph_click$y_closest_point))
+    paste0(
+      'X = ', format(strptime(req(input$dygraph_click$x_closest_point), '%m/%d/%Y, %I:%M:%S %p'), '%Y/%m/%d %H:%M:%S'),
+      '; Y = ', req(input$dygraph_click$y_closest_point)
+     )
   })
+  
 })

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -217,7 +217,7 @@ HTMLWidgets.widget({
               prevClickCallback(e, x, points);
             // fire input change
             Shiny.onInputChange(el.id + "_click", {
-              x: this.shinyValueFormatter(x),
+              date: this.shinyValueFormatter(x),
               x_closest_point: this.shinyValueFormatter(points[0].xval),
               y_closest_point: points[0].yval,
               '.nonce': Math.random() // Force reactivity if click hasn't changed

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -203,24 +203,28 @@ HTMLWidgets.widget({
         if (x.group != null)
           groups[x.group].push(dygraph);
         
-		// add callback
-		var prevClickCallback = dygraph.getOption("clickCallback")
+        // add callback
+        if (x.fixedtz) {
+          dygraph.shinyValueFormatter = this.xValueFormatterFixedTZ('seconds', x.tzone);
+        } else {
+          dygraph.shinyValueFormatter = this.xValueFormatter('seconds');
+        }
+        var prevClickCallback = dygraph.getOption("clickCallback")
         dygraph.updateOptions({
           clickCallback: function(e, x, points) {
             // call existing
             if (prevClickCallback)
               prevClickCallback(e, x, points);
-			// fire input change
+            // fire input change
             Shiny.onInputChange(el.id + "_click", {
-				x: new Date(x),
-				x_closest_point: new Date(points[0].xval),
-				y_closest_point: points[0].yval,
-				'.nonce': Math.random() // Force reactivity if click hasn't changed
-			}); 
-            
+              x: this.shinyValueFormatter(x),
+              x_closest_point: this.shinyValueFormatter(points[0].xval),
+              y_closest_point: points[0].yval,
+              '.nonce': Math.random() // Force reactivity if click hasn't changed
+            });             
           }
-        });		
-		
+        });
+
         // add shiny input for date window
         if (HTMLWidgets.shinyMode)
           this.addDateWindowShinyInput(el.id);
@@ -289,13 +293,13 @@ HTMLWidgets.widget({
               var start_offset_min = moment(v).tz(tz).zone();
               var check_dst = (p >= Dygraph.TICK_PLACEMENT[Dygraph.TWO_HOURLY].spacing);
               
-    	        if(a<=Dygraph.HOURLY){
-    		        for(t>v&&(v+=p,_=moment(v).tz(tz));e>=v;){
-    			        y.push({v:v,label:n(_,a,i,r)});
-    			        v+=p;
-    			        _=moment(v).tz(tz);
-    		        }
-    	        }else{
+              if(a<=Dygraph.HOURLY){
+                for(t>v&&(v+=p,_=moment(v).tz(tz));e>=v;){
+                  y.push({v:v,label:n(_,a,i,r)});
+                  v+=p;
+                  _=moment(v).tz(tz);
+                }
+              }else{
                 for(t>v&&(v+=p,_=moment(v).tz(tz));e>=v;){  
                 
                   // This ensures that we stay on the same hourly "rhythm" across
@@ -320,11 +324,11 @@ HTMLWidgets.widget({
                   }
                 
                   (a>=Dygraph.DAILY||_.get('hour')%h===0)&&y.push({v:v,label:n(_,a,i,r)});
-    			        v+=p;
-    			        _=moment(v).tz(tz);
-    		        }
-    	        }
-    	      }else{
+                  v+=p;
+                  _=moment(v).tz(tz);
+                }
+              }
+            }else{
               var start_year = moment(t).tz(tz).year();
               var end_year   = moment(e).tz(tz).year();
               var start_month = moment(t).tz(tz).month();
@@ -358,11 +362,11 @@ HTMLWidgets.widget({
                   ii+=step_year;
                 }
               }
-    	      }
-    	      return y;
-    	    }else{
+            }
+            return y;
+          }else{
            return []; 
-    	    }
+          }
         };
       },
     
@@ -647,7 +651,7 @@ HTMLWidgets.widget({
               prevDrawCallback(me, initial);
             // fire input change
             var range = dygraph.xAxisRange();
-            var dateWindow = [new Date(range[0]), new Date(range[1])];
+            var dateWindow = [this.shinyValueFormatter(range[0]), this.shinyValueFormatter(range[1])];
             Shiny.onInputChange(id + "_date_window", dateWindow); 
           }
         });


### PR DESCRIPTION
Hi,

I just noticed a bug with the shiny callbacks. 

Due to timezone issues, the shiny call backs (eg. `input$dygraph_date_window` and `input$dygraph_click$date`) were returning the incorrect date (out by one day for me in Australia). This pull request fixes them using the `xValueFormatter` and `xValueFormatterFixedTZ` methods defined for formatting values in the dygraphs.js script used for creating the graphs. 

Note that the callback value under `input$dygraph_click$date` is returned as a date-time-string for consistency with the value to "input$dygraph_date_window".

Sorry, I should have noticed before submitting the previous pull request.

Cheers,

Jeff