### PR TITLE
Added the series name to the output of the click callback

### DIFF
--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -657,6 +657,7 @@ HTMLWidgets.widget({
         				x: isDate ? new Date(x) : x,
         				x_closest_point: isDate ? new Date(points[0].xval) : points[0].xval,
         				y_closest_point: points[0].yval,
+        				series_name: points[0].name,
         				'.nonce': Math.random() // Force reactivity if click hasn't changed
   			      }); 
 			      }


### PR DESCRIPTION
This pull request adds another output to the click callback. 

When there are multiple series, in addition to the x and y coords its helpful to get the series name too.