### PR TITLE
Custom circles

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -24,6 +24,10 @@
 #'   is always drawn when a point is "isolated", i.e. there is a missing point 
 #'   on either side of it. This also controls the size of those dots. This 
 #'   option can also be set on a per-series basis.
+#' @param pointShape The shape of the dot to draw. Can be one of the following:
+#'   "dot" (default), "triangle", "square", "diamond", "pentagon", "hexagon",
+#'   "circle", "star", "plus" or "ex". This option can also be set on a per-series
+#'   basis.
 #' @param drawGapEdgePoints Draw points at the edges of gaps in the data. This 
 #'   improves visibility of small data segments or other data irregularities.
 #' @param connectSeparatedPoints Usually, when dygraphs encounters a missing 
@@ -162,6 +166,16 @@ dyOptions <- function(dygraph,
                       stemPlot = FALSE,
                       drawPoints = FALSE,
                       pointSize = 1.0,
+                      pointShape = c("dot",
+                                     "triangle",
+                                     "square",
+                                     "diamond",
+                                     "pentagon",
+                                     "hexagon",
+                                     "circle",
+                                     "star",
+                                     "plus",
+                                     "ex"),
                       drawGapEdgePoints = FALSE,
                       connectSeparatedPoints = FALSE,
                       strokeWidth = 1.0,
@@ -270,6 +284,12 @@ dyOptions <- function(dygraph,
   }
   dygraph$x$tzone <- data.timezone
   
+  # set point shape
+  pointShape <- match.arg(pointShape)
+  if (pointShape != "dot") {
+    dygraph$x$pointShape <- pointShape
+  }
+
   # return modified dygraph
   dygraph
 }

--- a/R/series.R
+++ b/R/series.R
@@ -33,6 +33,9 @@
 #' @param pointSize The size of the dot to draw on each point in pixels. A dot 
 #'   is always drawn when a point is "isolated", i.e. there is a missing point 
 #'   on either side of it. This also controls the size of those dots.
+#' @param pointShape The shape of the dot to draw. Can be one of the following:
+#'   "dot" (default), "triangle", "square", "diamond", "pentagon", "hexagon",
+#'   "circle", "star", "plus" or "ex".
 #' @param strokeWidth The width of the lines connecting data points. This can be
 #'   used to increase the contrast or some graphs.
 #' @param strokePattern A predefined stroke pattern type ("dotted", "dashed", or
@@ -75,6 +78,16 @@ dySeries <- function(dygraph,
                      fillGraph = NULL,
                      drawPoints = NULL,
                      pointSize = NULL,
+                     pointShape = c("dot",
+                                    "triangle",
+                                    "square",
+                                    "diamond",
+                                    "pentagon",
+                                    "hexagon",
+                                    "circle",
+                                    "star",
+                                    "plus",
+                                    "ex"),
                      strokeWidth = NULL,
                      strokePattern = NULL,
                      strokeBorderWidth = NULL,
@@ -129,6 +142,7 @@ dySeries <- function(dygraph,
   series$options$strokeBorderWidth <- strokeBorderWidth
   series$options$strokeBorderColor <- strokeBorderColor
   series$options$plotter <- JS(plotter)
+
  
   # copy attrs for modification
   attrs <- dygraph$x$attrs
@@ -177,6 +191,13 @@ dySeries <- function(dygraph,
   
   # set attrs
   dygraph$x$attrs <- attrs
+
+  # set point shape
+  pointShape <- match.arg(pointShape)
+  if (pointShape != "dot") {
+    dygraph$x$pointShape <- list()
+    dygraph$x$pointShape[[series$label]] <- pointShape
+  }
   
   # add data
   dygraph$x$data[[length(dygraph$x$data) + 1]] <- seriesData

--- a/R/series.R
+++ b/R/series.R
@@ -78,16 +78,7 @@ dySeries <- function(dygraph,
                      fillGraph = NULL,
                      drawPoints = NULL,
                      pointSize = NULL,
-                     pointShape = c("dot",
-                                    "triangle",
-                                    "square",
-                                    "diamond",
-                                    "pentagon",
-                                    "hexagon",
-                                    "circle",
-                                    "star",
-                                    "plus",
-                                    "ex"),
+                     pointShape = NULL,
                      strokeWidth = NULL,
                      strokePattern = NULL,
                      strokeBorderWidth = NULL,
@@ -193,10 +184,20 @@ dySeries <- function(dygraph,
   dygraph$x$attrs <- attrs
 
   # set point shape
-  pointShape <- match.arg(pointShape)
-  if (pointShape != "dot") {
-    dygraph$x$pointShape <- list()
-    dygraph$x$pointShape[[series$label]] <- pointShape
+  if (!is.null(pointShape)) {
+    shapes <- c("dot", "triangle", "square", "diamond", "pentagon",
+                "hexagon", "circle", "star", "plus", "ex")
+    if (!is.element(pointShape, shapes)) {
+      stop("Invalid value for pointShape parameter. ",
+           "Should be one of the following: ",
+           "'dot', 'triangle', 'square', 'diamond', 'pentagon', ",
+           "'hexagon', 'circle', 'star', 'plus' or 'ex'")
+    }
+
+    if (pointShape != "dot") {
+      dygraph$x$pointShape <- list()
+      dygraph$x$pointShape[[series$label]] <- pointShape
+    }
   }
   
   # add data

--- a/docs/gallery-series-options.Rmd
+++ b/docs/gallery-series-options.Rmd
@@ -46,13 +46,60 @@ dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
   dyOptions(drawPoints = TRUE, pointSize = 2)
 ```
 
+Different point shapes are available as well:
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "triangle")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "square")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "diamond")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "pentagon")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "hexagon")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "circle")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "star")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "plus")
+```
+
+```{r}
+dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
+  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "ex")
+```
+
 #### Per-Series Options
 
 All of the options above can also be set on a per-series basis using the `dySeries` function. For example:
 
 ```{r}
 dygraph(lungDeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dySeries("mdeaths", drawPoints = TRUE, color = "blue") %>%
+  dySeries("mdeaths", drawPoints = TRUE, pointShape = "square", color = "blue") %>%
   dySeries("fdeaths", stepPlot = TRUE, fillGraph = TRUE, color = "red")
 ```
 

--- a/docs/gallery-series-options.Rmd
+++ b/docs/gallery-series-options.Rmd
@@ -53,45 +53,7 @@ dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
   dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "triangle")
 ```
 
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "square")
-```
-
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "diamond")
-```
-
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "pentagon")
-```
-
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "hexagon")
-```
-
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "circle")
-```
-
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "star")
-```
-
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "plus")
-```
-
-```{r}
-dygraph(ldeaths, main = "Deaths from Lung Disease (UK)") %>%
-  dyOptions(drawPoints = TRUE, pointSize = 5, pointShape = "ex")
-```
+The possible parameters for `pointShape` are: `triangle`, `square`, `diamond`, `pentagon`, `hexagon`, `circle`, `star`, `plus` or `ex`.
 
 #### Per-Series Options
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+dygraphs 1.1.1.5 (unreleased)
+--------------------------------------------------------------------------------
+
+* Added pointShape parameter to dyOptions and dySeries function to set point shapes
+  other than dots
+
 dygraphs 1.1.1.4
 --------------------------------------------------------------------------------
 

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -141,6 +141,21 @@ HTMLWidgets.widget({
         if (x.dataHandler) {
           attrs.dataHandler = Dygraph.DataHandlers[x.dataHandler];
         }
+
+        // custom circles
+        if (x.pointShape) {
+          if (typeof x.pointShape === 'string') {
+            attrs.drawPointCallback = Dygraph.Circles[x.pointShape.toUpperCase()];
+            attrs.drawHighlightPointCallback = Dygraph.Circles[x.pointShape.toUpperCase()];
+          } else {
+            for (var s in x.pointShape) {
+              if (x.pointShape.hasOwnProperty(s)) {
+                attrs.series[s].drawPointCallback = Dygraph.Circles[x.pointShape[s].toUpperCase()];
+                attrs.series[s].drawHighlightPointCallback = Dygraph.Circles[x.pointShape[s].toUpperCase()];
+              }
+            }
+          }
+        }
     
         // if there is no existing dygraph perform initialization
         if (!dygraph) {

--- a/inst/htmlwidgets/dygraphs.yaml
+++ b/inst/htmlwidgets/dygraphs.yaml
@@ -6,7 +6,9 @@ dependencies:
   - name: dygraphs
     version: 1.1.1
     src: "htmlwidgets/lib/dygraphs"
-    script: dygraph-combined.js
+    script:
+      - dygraph-combined.js
+      - shapes.js
     stylesheet: dygraph.css
   - name: moment
     version: 2.8.4

--- a/inst/htmlwidgets/lib/dygraphs/shapes.js
+++ b/inst/htmlwidgets/lib/dygraphs/shapes.js
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2011 Dan Vanderkam (danvdk@gmail.com)
+ * MIT-licensed (http://opensource.org/licenses/MIT)
+ */
+
+/**
+ * @fileoverview
+ * Including this file will add several additional shapes to Dygraph.Circles
+ * which can be passed to drawPointCallback.
+ * See tests/custom-circles.html for usage.
+ */
+
+(function() {
+
+/**
+ * @param {!CanvasRenderingContext2D} ctx the canvas context
+ * @param {number} sides the number of sides in the shape.
+ * @param {number} radius the radius of the image.
+ * @param {number} cx center x coordate
+ * @param {number} cy center y coordinate
+ * @param {number=} rotationRadians the shift of the initial angle, in radians.
+ * @param {number=} delta the angle shift for each line. If missing, creates a
+ *     regular polygon.
+ */
+var regularShape = function(
+    ctx, sides, radius, cx, cy, rotationRadians, delta) {
+  rotationRadians = rotationRadians || 0;
+  delta = delta || Math.PI * 2 / sides;
+
+  ctx.beginPath();
+  var initialAngle = rotationRadians;
+  var angle = initialAngle;
+
+  var computeCoordinates = function() {
+    var x = cx + (Math.sin(angle) * radius);
+    var y = cy + (-Math.cos(angle) * radius);
+    return [x, y];
+  };
+
+  var initialCoordinates = computeCoordinates();
+  var x = initialCoordinates[0];
+  var y = initialCoordinates[1];
+  ctx.moveTo(x, y);
+
+  for (var idx = 0; idx < sides; idx++) {
+    angle = (idx == sides - 1) ? initialAngle : (angle + delta);
+    var coords = computeCoordinates();
+    ctx.lineTo(coords[0], coords[1]);
+  }
+  ctx.fill();
+  ctx.stroke();
+};
+
+/**
+ * TODO(danvk): be more specific on the return type.
+ * @param {number} sides
+ * @param {number=} rotationRadians
+ * @param {number=} delta
+ * @return {Function}
+ * @private
+ */
+var shapeFunction = function(sides, rotationRadians, delta) {
+  return function(g, name, ctx, cx, cy, color, radius) {
+    ctx.strokeStyle = color;
+    ctx.fillStyle = "white";
+    regularShape(ctx, sides, radius, cx, cy, rotationRadians, delta);
+  };
+};
+
+var customCircles = {
+  TRIANGLE : shapeFunction(3),
+  SQUARE : shapeFunction(4, Math.PI / 4),
+  DIAMOND : shapeFunction(4),
+  PENTAGON : shapeFunction(5),
+  HEXAGON : shapeFunction(6),
+  CIRCLE : function(g, name, ctx, cx, cy, color, radius) {
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.fillStyle = "white";
+    ctx.arc(cx, cy, radius, 0, 2 * Math.PI, false);
+    ctx.fill();
+    ctx.stroke();
+  },
+  STAR : shapeFunction(5, 0, 4 * Math.PI / 5),
+  PLUS : function(g, name, ctx, cx, cy, color, radius) {
+    ctx.strokeStyle = color;
+
+    ctx.beginPath();
+    ctx.moveTo(cx + radius, cy);
+    ctx.lineTo(cx - radius, cy);
+    ctx.closePath();
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(cx, cy + radius);
+    ctx.lineTo(cx, cy - radius);
+    ctx.closePath();
+    ctx.stroke();
+  },
+  EX : function(g, name, ctx, cx, cy, color, radius) {
+    ctx.strokeStyle = color;
+
+    ctx.beginPath();
+    ctx.moveTo(cx + radius, cy + radius);
+    ctx.lineTo(cx - radius, cy - radius);
+    ctx.closePath();
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(cx + radius, cy - radius);
+    ctx.lineTo(cx - radius, cy + radius);
+    ctx.closePath();
+    ctx.stroke();
+  }
+};
+
+for (var k in customCircles) {
+  if (!customCircles.hasOwnProperty(k)) continue;
+  Dygraph.Circles[k] = customCircles[k];
+}
+
+})();

--- a/man/dyOptions.Rd
+++ b/man/dyOptions.Rd
@@ -6,18 +6,20 @@
 \usage{
 dyOptions(dygraph, stackedGraph = FALSE, fillGraph = FALSE,
   fillAlpha = 0.15, stepPlot = FALSE, stemPlot = FALSE,
-  drawPoints = FALSE, pointSize = 1, drawGapEdgePoints = FALSE,
-  connectSeparatedPoints = FALSE, strokeWidth = 1, strokePattern = NULL,
-  strokeBorderWidth = NULL, strokeBorderColor = "white", plotter = NULL,
-  colors = NULL, colorValue = 0.5, colorSaturation = 1,
-  drawXAxis = TRUE, drawYAxis = TRUE, includeZero = FALSE,
-  drawAxesAtZero = FALSE, logscale = FALSE, axisTickSize = 3,
-  axisLineColor = "black", axisLineWidth = 0.3, axisLabelColor = "black",
-  axisLabelFontSize = 14, axisLabelWidth = 60, drawGrid = TRUE,
-  gridLineColor = NULL, gridLineWidth = 0.3, titleHeight = NULL,
-  rightGap = 5, digitsAfterDecimal = 2, labelsKMB = FALSE,
-  labelsKMG2 = FALSE, labelsUTC = FALSE, maxNumberWidth = 6,
-  sigFigs = NULL, panEdgeFraction = NULL, animatedZooms = FALSE,
+  drawPoints = FALSE, pointSize = 1, pointShape = c("dot", "triangle",
+  "square", "diamond", "pentagon", "hexagon", "circle", "star", "plus", "ex"),
+  drawGapEdgePoints = FALSE, connectSeparatedPoints = FALSE,
+  strokeWidth = 1, strokePattern = NULL, strokeBorderWidth = NULL,
+  strokeBorderColor = "white", plotter = NULL, colors = NULL,
+  colorValue = 0.5, colorSaturation = 1, drawXAxis = TRUE,
+  drawYAxis = TRUE, includeZero = FALSE, drawAxesAtZero = FALSE,
+  logscale = FALSE, axisTickSize = 3, axisLineColor = "black",
+  axisLineWidth = 0.3, axisLabelColor = "black", axisLabelFontSize = 14,
+  axisLabelWidth = 60, drawGrid = TRUE, gridLineColor = NULL,
+  gridLineWidth = 0.3, titleHeight = NULL, rightGap = 5,
+  digitsAfterDecimal = 2, labelsKMB = FALSE, labelsKMG2 = FALSE,
+  labelsUTC = FALSE, maxNumberWidth = 6, sigFigs = NULL,
+  panEdgeFraction = NULL, animatedZooms = FALSE,
   mobileDisableYTouch = TRUE, timingName = NULL, useDataTimezone = FALSE,
   retainDateWindow = FALSE)
 }
@@ -51,6 +53,11 @@ per-series basis.}
 is always drawn when a point is "isolated", i.e. there is a missing point 
 on either side of it. This also controls the size of those dots. This 
 option can also be set on a per-series basis.}
+
+\item{pointShape}{The shape of the dot to draw. Can be one of the following:
+"dot" (default), "triangle", "square", "diamond", "pentagon", "hexagon",
+"circle", "star", "plus" or "ex". This option can also be set on a per-series
+basis.}
 
 \item{drawGapEdgePoints}{Draw points at the edges of gaps in the data. This 
 improves visibility of small data segments or other data irregularities.}

--- a/man/dySeries.Rd
+++ b/man/dySeries.Rd
@@ -6,8 +6,10 @@
 \usage{
 dySeries(dygraph, name = NULL, label = NULL, color = NULL, axis = "y",
   stepPlot = NULL, stemPlot = NULL, fillGraph = NULL, drawPoints = NULL,
-  pointSize = NULL, strokeWidth = NULL, strokePattern = NULL,
-  strokeBorderWidth = NULL, strokeBorderColor = NULL, plotter = NULL)
+  pointSize = NULL, pointShape = c("dot", "triangle", "square", "diamond",
+  "pentagon", "hexagon", "circle", "star", "plus", "ex"), strokeWidth = NULL,
+  strokePattern = NULL, strokeBorderWidth = NULL,
+  strokeBorderColor = NULL, plotter = NULL)
 }
 \arguments{
 \item{dygraph}{Dygraph to add a series definition to}
@@ -45,6 +47,10 @@ can increase visual clutter in the chart.}
 \item{pointSize}{The size of the dot to draw on each point in pixels. A dot 
 is always drawn when a point is "isolated", i.e. there is a missing point 
 on either side of it. This also controls the size of those dots.}
+
+\item{pointShape}{The shape of the dot to draw. Can be one of the following:
+"dot" (default), "triangle", "square", "diamond", "pentagon", "hexagon",
+"circle", "star", "plus" or "ex".}
 
 \item{strokeWidth}{The width of the lines connecting data points. This can be
 used to increase the contrast or some graphs.}

--- a/man/dySeries.Rd
+++ b/man/dySeries.Rd
@@ -6,8 +6,7 @@
 \usage{
 dySeries(dygraph, name = NULL, label = NULL, color = NULL, axis = "y",
   stepPlot = NULL, stemPlot = NULL, fillGraph = NULL, drawPoints = NULL,
-  pointSize = NULL, pointShape = c("dot", "triangle", "square", "diamond",
-  "pentagon", "hexagon", "circle", "star", "plus", "ex"), strokeWidth = NULL,
+  pointSize = NULL, pointShape = NULL, strokeWidth = NULL,
   strokePattern = NULL, strokeBorderWidth = NULL,
   strokeBorderColor = NULL, plotter = NULL)
 }


### PR DESCRIPTION
This PR adds new parameter `pointShape` to `dyOptions` and `dySeries` functions to add the ability to specify point shapes other than plain dots.

See for example http://dygraphs.com/tests/custom-circles.html