### PR TITLE
Add disable zoom option to dyOptions

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -215,7 +215,7 @@ dyOptions <- function(dygraph,
                       timingName = NULL,
                       useDataTimezone = FALSE,
                       retainDateWindow = FALSE,
-                      disableZoom = TRUE) {
+                      disableZoom = FALSE) {
   
   # validate that labelsUTC and useDataTimezone aren't specified together
   if (!missing(labelsUTC) && !missing(useDataTimezone))

--- a/R/options.R
+++ b/R/options.R
@@ -151,6 +151,7 @@
 #' @param retainDateWindow Whether to retain the user's current date window 
 #'   (zoom level) when updating an existing dygraph with new data and/or 
 #'   options.
+#' @param disableZoom Set this option to disable click and drag zooming.
 #'   
 #' @return dygraph with additional options
 #'   
@@ -213,7 +214,8 @@ dyOptions <- function(dygraph,
                       mobileDisableYTouch = TRUE,
                       timingName = NULL,
                       useDataTimezone = FALSE,
-                      retainDateWindow = FALSE) {
+                      retainDateWindow = FALSE,
+                      disableZoom = TRUE) {
   
   # validate that labelsUTC and useDataTimezone aren't specified together
   if (!missing(labelsUTC) && !missing(useDataTimezone))
@@ -268,6 +270,7 @@ dyOptions <- function(dygraph,
   options$timingName <- timingName
   if (!missing(retainDateWindow))
     options$retainDateWindow <- retainDateWindow
+  options$disableZoom <- disableZoom
   
   # merge options into attrs
   dygraph$x$attrs <- mergeLists(dygraph$x$attrs, options)

--- a/inst/htmlwidgets/dygraphs.js
+++ b/inst/htmlwidgets/dygraphs.js
@@ -48,6 +48,11 @@ HTMLWidgets.widget({
         // get dygraph attrs and populate file field
         var attrs = x.attrs;
         attrs.file = x.data;
+	      
+	// disable zoom interaction except for clicks
+        if (attrs.disableZoom !== false) {
+          attrs.interactionModel = Dygraph.Interaction.nonInteractiveModel_;
+        }
         
         // convert non-arrays to arrays
         for (var index = 0; index < attrs.file.length; index++) {

--- a/man/dyOptions.Rd
+++ b/man/dyOptions.Rd
@@ -21,7 +21,7 @@ dyOptions(dygraph, stackedGraph = FALSE, fillGraph = FALSE,
   labelsUTC = FALSE, maxNumberWidth = 6, sigFigs = NULL,
   panEdgeFraction = NULL, animatedZooms = FALSE,
   mobileDisableYTouch = TRUE, timingName = NULL, useDataTimezone = FALSE,
-  retainDateWindow = FALSE)
+  retainDateWindow = FALSE, disableZoom = FALSE)
 }
 \arguments{
 \item{dygraph}{Dygraph to add options to}
@@ -219,6 +219,9 @@ the client workstation. Note that this option is incompatible with
 \item{retainDateWindow}{Whether to retain the user's current date window 
 (zoom level) when updating an existing dygraph with new data and/or 
 options.}
+}
+
+\item{disableZoom}{Set this option to disable click and drag zooming.}
 }
 \value{
 dygraph with additional options


### PR DESCRIPTION
Allow the interaction model to be changed to disable zoom in dyOptions.

[https://groups.google.com/forum/#!topic/dygraphs-users/l5LscNWBS_4](https://groups.google.com/forum/#!topic/dygraphs-users/l5LscNWBS_4)

I know zooming is one of the coolest parts of dygraphs, but sometimes it is necessary.

Also this is my first pull request so I really hope I have followed best practice and it is easy to review my proposed change. Please let me know if I should move options around or rename things.

Thanks heaps,
Hayden