### PR TITLE
New color scheme

### DIFF
--- a/R/series.R
+++ b/R/series.R
@@ -15,11 +15,8 @@
 #'   and upper for a series with a shaded bar drawn around it.
 #' @param label Label to display for series (uses name if no label defined)
 #' @param color Color for series. These can be of the form "#AABBCC" or 
-#'   "rgb(255,100,200)" or "yellow", etc. Note that if you specify a custom 
-#'   color for one series then you must specify one for all series. If not 
-#'   specified then the global colors option (typically based on equally-spaced 
-#'   points around a color wheel). Note also that global and per-series color 
-#'   specification cannot be mixed.
+#'   "rgb(255,100,200)" or "yellow", etc. If not specified then the global 
+#'   colors option (typically based on equally-spaced points around a color wheel). 
 #' @param axis Y-axis to associate the series with ("y" or "y2")
 #' @param stepPlot When set, display the graph as a step plot instead of a line 
 #'   plot.
@@ -89,6 +86,18 @@ dySeries <- function(dygraph,
   data <- attr(dygraph$x, "data")
   labels <- names(data)
   
+  # when setting up the first color, we start handling colors here 
+  if(!is.null(color) && is.null(dygraph$x$attrs$colors)){
+      colors <- dygraphColors(dygraph, length(labels)-1)
+      dygraph$x$attrs$colors <- colors
+  }
+
+  # prepare the colors list for processing 
+  if(!is.null(dygraph$x$attrs$colors)) {
+     colors <- dygraph$x$attrs$colors
+     names(colors) <- dygraph$x$attrs$labels[-1]
+  }
+   
   # auto-bind name if necessary
   autobind <- attr(dygraph$x, "autoSeries")
   if (is.null(name))
@@ -108,6 +117,7 @@ dySeries <- function(dygraph,
     stop("One or more of the specified series were not found. ",
          "Valid series names are: ", paste(labels[-1], collapse = ", "))
   }
+  
   
   # Data series named here are "consumed" from the automatically generated
   # list of series (they'll be added back in below)
@@ -166,35 +176,18 @@ dySeries <- function(dygraph,
     seriesData <- data[[series$name]]
   }
   
-  # add color if specified 
-  # This area could be supplemented to set all colors for all data series by extracting
-  # the method for how dygraphs sets the underlying colors.  This would eliminate the
-  # need to set all colors if only one is explicitly set
-  # 
-  # Also, moved this area up to grab all the colors already set before the series 
-  # processed during this run through dySeries is added
-  if (!is.null(color)) {
-    #grab the names of all named series 
-    names_ <- names(attrs$series)
-   
-    #grab any colors already set
-    colors_ <- attrs$colors
-   
-    # if no colors passed thus far, set up the color vector for
-    # the series defined previously
-    if(is.null(colors_)) {
-      colors_ <- vector('character', length(names_))
-    }
-    names(colors_) <- names_
+  # grab the colors for the series being processed
+  if (!is.null(dygraph$x$attrs$colors)) {
+    currColors <- colors[names(colors) %in% name]
+    if(!is.null(color)) currColors[[series$name]] <- color
     
-    colors_[[name]] <- color
+    colors <- colors[!names(colors) %in% name]
+    colors[[series$name]] <- currColors[[series$name]]
     
-    # all options must be unnamed vectors
-    names(colors_) <- NULL
-    
-    # attrs$colors <- as.list(c(attrs$colors, color))
-    attrs$colors <- colors_
+    attrs$colors <- colors
+    names(attrs$colors) <- NULL
   }
+  
   
   # default the label if we need to
   if (is.null(series$label))
@@ -315,10 +308,55 @@ resolveStemPlot <- function(stemPlot, plotter) {
   }
 }
 
+dygraphColors <- function(dygraph, num) {
+  series <- length(dygraph$x$attrs$series)
 
+  # These are used for when no custom colors are specified.
+  sat <- dygraph$x$attrs$colorSaturation %||% 1.0
+  val <- dygraph$x$attrs$colorValue %||% 0.5
+  half <- ceiling(num / 2)
+  
+  colors<-c()
+  
+  for (i in 1:num){
+    # alternate colors for high contrast.
+    idx <- ifelse(i %% 2, (half + (i + 1)/ 2), ceiling((i + 1) / 2))
+    hue <- (1.0 * idx / (1 + num))
+    color <- hsvToRGB(hue, sat, val)
+    colors <- c(colors, color)
+  }
+  return(colors)
+}
 
+hsvToRGB <- function (hue, saturation, value) {
+  if (saturation == 0) {
+    red = value
+    green = value
+    blue = value
+  } else {
+    i <- floor(hue * 6)
+    f <- (hue * 6) - i
+    p <- value * (1 - saturation)
+    q <- value * (1 - (saturation * f))
+    t <- value * (1 - (saturation * (1 - f)))
+    # red <- switch(i, 1 = q, 2 = p, 3 = p, 4 = t, 5 = value, 6 = value, 0 = value)
+    # green <- switch(i, 1 = value, 2 = value, 3 = q, 4 = p, 5 = p, 6 = t, 0 = t)
+    # blue <- switch(i, 1 = p, 2 = t, 3 = value, 4 = value, 5 = q, 6 = p, 0 = p)
+    red <- c(value, q, p, p, t, value, value)
+    green <- c(t, value, value, q, p, p, t)
+    blue <- c(p, p, t, value, value, q, p)
+    
+    r <- red[i+1]
+    g <- green[i+1]
+    b <- blue[i+1]
+  }
+  red <- floor(255 * r + 0.5);
+  green <- floor(255 * g + 0.5);
+  blue <- floor(255 * b + 0.5);
+  return (rgb(red, green, blue, maxColorValue = 255))
+}
 
-
-
-
-
+`%||%` <- function(a,b){
+  if(!is.null(a)) return(a)
+  else return(b)
+}

--- a/docs/gallery-series-options.Rmd
+++ b/docs/gallery-series-options.Rmd
@@ -65,8 +65,6 @@ dygraph(lungDeaths, main = "Deaths from Lung Disease (UK)") %>%
   dySeries("fdeaths", stepPlot = TRUE, fillGraph = TRUE, color = "red")
 ```
 
-Note that you can specify colors globally (as demonstrated above) or per-series, but you cannot mix both styles of assigning colors.
-
 #### Line Strokes
 
 You can also customize the way that series lines are drawn. Here we draw a wider line with a custom stroke pattern (dashed line):

--- a/inst/plotters/stackedribbongroup.js
+++ b/inst/plotters/stackedribbongroup.js
@@ -257,7 +257,7 @@ function linePlotter(e) {
 					//
 		//BEGIN THE FILL
     var stepPlot = g.getBooleanOption('stepPlot', setName);
-		var color = fillColors[j];
+		var color = e.color;
 		var axis = g.axisPropertiesForSeries(setName);
     var axisY = 1.0 + axis.minyval * axis.yscale;
     if (axisY < 0.0) axisY = 0.0;

--- a/man/dyGroup.Rd
+++ b/man/dyGroup.Rd
@@ -21,12 +21,9 @@ and upper for a series with a shaded bar drawn around it.}
 
 \item{label}{Labels to display for series (uses name if no label defined)}
 
-\item{color}{Colors for series. These can be of the form "#AABBCC" or 
-"rgb(255,100,200)" or "yellow", etc. Note that if you specify a custom 
-color for one series then you must specify one for all series. If not 
-specified then the global colors option (typically based on equally-spaced 
-points around a color wheel). Note also that global and per-series color 
-specification cannot be mixed.}
+\item{color}{Color for series. These can be of the form "#AABBCC" or 
+"rgb(255,100,200)" or "yellow", etc. If not specified then the global 
+colors option (typically based on equally-spaced points around a color wheel).}
 
 \item{axis}{Y-axis to associate the series with ("y" or "y2")}
 

--- a/man/dySeries.Rd
+++ b/man/dySeries.Rd
@@ -22,11 +22,8 @@ and upper for a series with a shaded bar drawn around it.}
 \item{label}{Label to display for series (uses name if no label defined)}
 
 \item{color}{Color for series. These can be of the form "#AABBCC" or 
-"rgb(255,100,200)" or "yellow", etc. Note that if you specify a custom 
-color for one series then you must specify one for all series. If not 
-specified then the global colors option (typically based on equally-spaced 
-points around a color wheel). Note also that global and per-series color 
-specification cannot be mixed.}
+"rgb(255,100,200)" or "yellow", etc. If not specified then the global 
+colors option (typically based on equally-spaced points around a color wheel).}
 
 \item{axis}{Y-axis to associate the series with ("y" or "y2")}
 


### PR DESCRIPTION
This PR allows users to mix the global coloring and per-series colors.  Three notes of worth:
* The current API for the R package doesn't always maintain color order. When series are not modified in the order they appear in the underlying data, the colors assigned by the global coloring scheme get reordered (e.g., the last series modified will get the last color in the color vector created by the dygraphs lib.)  This PR does __not__ correct for that.
* The new coloring scheme has been updated for both `dySeries` and `dyGroup`, and I've tested with all the examples in the documentation for `dySeries`, `dyGroup`, and the `Plotters`; all dygraphs render appropriately on my end. 
* I'm having this weird thing where knitting `.Rmd` to `.html` eliminates the ability to zoom, though not in all dygraphs.  Sooooo, while I've changed the `http://rstudio.github.io/dygraphs` documentation for the `.Rmd` file, this PR does __not__ include the `.html` version. I need to rely on someone else to generate the `.html` that works properly. The package documentation has been updated accordingly.