### PR TITLE
Fix for hidden crosshairs + added color option

### DIFF
--- a/R/plugins.R
+++ b/R/plugins.R
@@ -29,6 +29,7 @@ dyUnzoom <-function(dygraph) {
 #' @param dygraph Dygraph to add plugin to
 #' @param direction Crosshair direction. Valid options are: "both", "horizontal",
 #' "vertical"
+#' @param color Crosshair color in RGB form ("#ff0088" or rgb(255,0,136)), default black and 0.3 alpha.
 #'
 #' @return Dygraph with Crosshair plugin enabled
 #'
@@ -39,12 +40,12 @@ dyUnzoom <-function(dygraph) {
 #'   dyCrosshair(direction = "vertical")
 #'
 #' @export
-dyCrosshair <- function(dygraph, direction = c("both", "horizontal", "vertical")) {
+dyCrosshair <- function(dygraph, direction = c("both", "horizontal", "vertical"), color=rgb(0,0,0,0.3)) {
   dyPlugin(
     dygraph = dygraph,
     name = "Crosshair",
     path = system.file("plugins/crosshair.js", package = "dygraphs"),
-    options = list(direction = match.arg(direction))
+    options = list(direction = match.arg(direction), color=color)
   )
 }
 

--- a/inst/plugins/crosshair.js
+++ b/inst/plugins/crosshair.js
@@ -17,8 +17,13 @@ Dygraph.Plugins.Crosshair = (function() {
 
   var crosshair = function(opt_options) {
     this.canvas_ = document.createElement("canvas");
+    this.canvas_.style.zIndex = 1;
+    this.canvas_.style.position = "absolute";
+    this.canvas_.style.pointerEvents = "none";
+    
     opt_options = opt_options || {};
     this.direction_ = opt_options.direction || null;
+    this.color_ = opt_options.color || "rgba(0, 0, 0,0.3)"
   };
 
   crosshair.prototype.toString = function() {
@@ -52,7 +57,7 @@ Dygraph.Plugins.Crosshair = (function() {
 
     var ctx = this.canvas_.getContext("2d");
     ctx.clearRect(0, 0, width, height);
-    ctx.strokeStyle = "rgba(0, 0, 0,0.3)";
+    ctx.strokeStyle = this.color_;
     ctx.beginPath();
 
     var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering

--- a/man/dyCrosshair.Rd
+++ b/man/dyCrosshair.Rd
@@ -7,13 +7,15 @@ mouse when the user hovers over the graph. It has a "direction" option which
 is provided in the R wrapper function and then forwarded to the plugin using
 the "options" argument to dyPlugin.}
 \usage{
-dyCrosshair(dygraph, direction = c("both", "horizontal", "vertical"))
+dyCrosshair(dygraph, direction = c("both", "horizontal", "vertical"), color=rgb(0,0,0,0.3))
 }
 \arguments{
 \item{dygraph}{Dygraph to add plugin to}
 
 \item{direction}{Crosshair direction. Valid options are: "both", "horizontal",
 "vertical"}
+  
+\item{color}{Color and alpha (transparency) of crosshair}
 }
 \value{
 Dygraph with Crosshair plugin enabled
@@ -28,6 +30,6 @@ the "options" argument to dyPlugin.
 library(dygraphs)
 dygraph(ldeaths) \%>\%
   dyRangeSelector() \%>\%
-  dyCrosshair(direction = "vertical")
-
+  dyCrosshair(direction = "vertical", 
+  color=rgb(1.0,0,0,0.5))
 }

--- a/man/dyCrosshair.Rd
+++ b/man/dyCrosshair.Rd
@@ -30,6 +30,5 @@ the "options" argument to dyPlugin.
 library(dygraphs)
 dygraph(ldeaths) \%>\%
   dyRangeSelector() \%>\%
-  dyCrosshair(direction = "vertical", 
-  color=rgb(1.0,0,0,0.5))
+  dyCrosshair(direction = "vertical", color=rgb(1.0,0,0,0.5))
 }


### PR DESCRIPTION
Crosshairs were hidden beneath any shading in a graph.  This was due to the crosshair canvas being below the graph canvas.   This was solved by changing the z-index, position type, and allowing events to pass through to lower canvas layers.

Also added a color option to dyCrosshairs(), to allow users to change the color of the crosshair.

Added the new optional parameter in the documentation and example.