### PR TITLE
Added NaN preserving toJSON function

### DIFF
--- a/R/dygraph.R
+++ b/R/dygraph.R
@@ -110,11 +110,12 @@ dygraph <- function(data, main = NULL, xlab = NULL, ylab = NULL,
   attr(x, "time") <- if (format == "date") time else NULL
   attr(x, "data") <- data
   attr(x, "autoSeries") <- 2
+  attr(x, "TOJSON_FUNC") <- toJSON_NaN
   
   # add data (strip names first so we marshall as a 2d array)
   names(data) <- NULL
   x$data <- data
-    
+  
   # create widget
   htmlwidgets::createWidget(
     name = "dygraphs",

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,3 +58,21 @@ defaultPeriodicity <- function (data) {
     class = "periodicity")
 }
 
+# custom toJSON handler to preserve NaN values.
+toJSON_NaN <- function(
+  x, ...,  dataframe = "columns", null = "null", na = "string", auto_unbox = TRUE,
+  digits = getOption("shiny.json.digits", 16), use_signif = TRUE, force = TRUE,
+  POSIXt = "ISO8601", UTC = TRUE, rownames = FALSE, keep_vec_names = TRUE,
+  strict_atomic = TRUE
+) {
+  if (strict_atomic) x <- I(x)
+  gsub(
+    '"NA"', 'null', 
+    jsonlite::toJSON(
+      x, dataframe = dataframe, null = null, na = na, auto_unbox = auto_unbox,
+      digits = digits, use_signif = use_signif, force = force, POSIXt = POSIXt,
+      UTC = UTC, rownames = rownames, keep_vec_names = keep_vec_names,
+      json_verbatim = TRUE, ...
+    )
+  )
+}


### PR DESCRIPTION
NaN values have special meaning in dygraphs, as they cause series gaps even when `connectSeparatedPoints = TRUE`.

> `connectSeparatedPoints`

> Usually, when Dygraphs encounters a missing value in a data series, it interprets this as a gap and draws it as such. If, instead, the missing values represents an x-value for which only a different series has data, then you'll want to connect the dots by setting this to true. **To explicitly include a gap with this option set, use a value of NaN.**

This is particularly important when plotting multiple time series which may be observed at different time points, that may contain missing values.

This functionality is also demonstrated here: http://dygraphs.com/tests/independent-series.html